### PR TITLE
Track known broken tests

### DIFF
--- a/client/Main.ml
+++ b/client/Main.ml
@@ -141,6 +141,11 @@ let translate log t =
 
 (* -------------------------------------------------------------------------- *)
 
+let failing_test_count = ref 0
+
+(* -------------------------------------------------------------------------- *)
+
+
 (* Running all passes over a single ML term. *)
 
 type example = { name : string
@@ -1519,3 +1524,9 @@ let () =
   test fml_poly_binding_4;
 
   test fml_scoped_tyvars_1
+
+;;
+
+
+if !failing_test_count > 0 then
+  exit 1

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -152,7 +152,11 @@ type example = { name : string
                ; term : ML.term
                ; typ  : debruijn_type option }
 
-let test { name; term; typ } : unit =
+(* The returned boolean indicates if the example "works", meaning that
+   - the term had the expected type    or
+   - failed to typecheck as expected.
+  An implementation bug always means that the example doesn't work. *)
+let test_driver { name; term; typ } : log * bool =
   let log = create_log() in
   log_action log (fun () ->
       Printf.printf "\n===========================================\n\n%!";
@@ -169,10 +173,7 @@ let test { name; term; typ } : unit =
      log_action log (fun () ->
          Printf.printf "Example %s was rejected by the typechecker as expected.\n" name;
        );
-     if verbose then
-       print_log log;
-     Printf.printf "\027[32mExample %s works as expected\027[0m\n" name;
-     flush stdout
+     log, true
 
   | WellTyped (t : F.nominal_term), Some exp_ty ->
       let works = ref false in
@@ -225,13 +226,7 @@ let test { name; term; typ } : unit =
             if ( exp_ty = ty ) then works := true else works := false
          end;
       end;
-      if verbose then
-        print_log log;
-      if ( !works ) then
-        Printf.printf "\027[32mExample %s works as expected\027[0m\n" name
-      else
-        Printf.printf "\027[31mExample %s does not work as expected\027[0m\n" name;
-     flush stdout
+      log, !works
   | IllTyped, Some exp_ty ->
      log_action log (fun () ->
          Printf.printf "Example %s expected to have a type:\n" name;
@@ -239,10 +234,7 @@ let test { name; term; typ } : unit =
          PPrint.ToChannel.pretty 0.9 80 stdout doc;
          Printf.printf "but was determined ill-typed.\n";
        );
-     if verbose then
-       print_log log;
-     Printf.printf "\027[31mExample %s does not work as expected\027[0m\n" name;
-     flush stdout
+     log, false
 
   | WellTyped t, None ->
       log_action log (fun () ->
@@ -281,20 +273,49 @@ let test { name; term; typ } : unit =
               );
          end;
       end;
-      if verbose then
-        print_log log;
-      Printf.printf "\027[31mExample %s does not work as expected\027[0m\n" name;
-     flush stdout
+      log, false
 
   | ImplementationBug, _ ->
      (* Typechecking caused an exception *)
      log_action log (fun () ->
          Printf.printf "Example %s triggered an implementation bug!\n" name;
        );
-     if verbose then
-       print_log log;
-     Printf.printf "\027[31mExample %s does not work as expected\027[0m\n" name;
-     flush stdout
+     log, false
+
+
+let test t : unit =
+  let name = t.name in
+  let log, works = test_driver t in
+  if verbose then
+    print_log log;
+  if ( works ) then
+    Printf.printf "\027[32mExample %s works as expected\027[0m\n" name
+  else
+    begin
+      Printf.printf "\027[31mExample %s does not work as expected\027[0m\n"
+        name;
+      failing_test_count := !failing_test_count + 1
+    end
+
+
+let known_broken_test t : unit =
+  let name = t.name in
+  let log, works = test_driver t in
+  if verbose then
+    print_log log;
+  if ( works ) then
+    begin
+      Printf.printf "\027[31mExample %s isn't broken anymore, great! Please \
+                     investigae and switch it to use the normal \"test\" \
+                     driver\027[0m\n" name;
+      (* We count this as a "failure" to encourage people to investigate and
+       switch the driver if things indeed work now *)
+      failing_test_count := !failing_test_count + 1
+    end
+  else
+    Printf.printf "\027[33mExample %s is broken, which is currently a \
+                   known problem\027[0m\n" name
+
 
 (* -------------------------------------------------------------------------- *)
 
@@ -1496,7 +1517,7 @@ let () =
   test fml_id_annot_1;
   test fml_id_annot_2;
   test fml_id_annot_3;
-  test fml_id_annot_4;
+  known_broken_test fml_id_annot_4;
   test fml_id_annot_5;
   test fml_mono_binder_constraint_1;
   test fml_mono_binder_constraint_2;
@@ -1514,10 +1535,10 @@ let () =
   test fml_alpha_equiv_3;
   test fml_alpha_equiv_4;
   test fml_alpha_equiv_5;
-  test fml_alpha_equiv_6;
+  known_broken_test fml_alpha_equiv_6;
 
-  test fml_mixed_prefix_1;
-  test fml_mixed_prefix_2;
+  known_broken_test fml_mixed_prefix_1;
+  known_broken_test fml_mixed_prefix_2;
   test fml_poly_binding_1;
   test fml_poly_binding_2;
   test fml_poly_binding_3;

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -143,6 +143,19 @@ let translate log t =
 
 let failing_test_count = ref 0
 
+let print_summary_and_exit () =
+  if !failing_test_count > 0 then
+    begin
+      Printf.printf "\n\027[31mSummary: There were %d problem(s)\027[0m\n"
+        !failing_test_count;
+      exit 1
+    end
+  else
+    begin
+      Printf.printf "\n\027[32mSummary: All tests behave as expected\027[0m\n";
+      exit 0
+    end
+
 (* -------------------------------------------------------------------------- *)
 
 
@@ -1549,5 +1562,4 @@ let () =
 ;;
 
 
-if !failing_test_count > 0 then
-  exit 1
+let () = print_summary_and_exit ()


### PR DESCRIPTION
I got a bit annoyed by the fact that we have tests that are known to be failing because I keep losing track which those are when working with multiple branches.

I added `known_broken_test`, which will "succeed" if the test is indeed broken, and will alert you if it suddenly changes it's behavior and starts working.

I've also implemented that we print a summary at the end, stating whether there were problems or not. In particular, a test that doesn't work but is known to be broken doesn't count as a problem.