### PR TITLE
Fix annotations on frozen variables and applications

### DIFF
--- a/client/Client.ml
+++ b/client/Client.ml
@@ -226,6 +226,10 @@ let product_i i x y =
   else
     product y x
 
+let is_gval = function
+  | ML.App _ | ML.FrozenVar _ -> false
+  | _                         -> true
+
 (* Ensures that all elements of xs appearing in ys appear at the front and in
    the same order *)
 let rec align_order equal xs ys = match xs, ys with
@@ -277,10 +281,6 @@ let ftyabs1 v t =
       t
   | t ->
       F.TyAbs (v, t)
-
-let is_gval = function
-  | ML.App _ | ML.FrozenVar _ -> false
-  | _                         -> true
 
 (* TEMPORARY find a better name for [coerce] *)
 

--- a/client/Client.ml
+++ b/client/Client.ml
@@ -278,6 +278,10 @@ let ftyabs1 v t =
   | t ->
       F.TyAbs (v, t)
 
+let is_gval = function
+  | ML.App _ | ML.FrozenVar _ -> false
+  | _                         -> true
+
 (* TEMPORARY find a better name for [coerce] *)
 
 let coerce (vs1 : O.tyvar list) (vs2 : O.tyvar list) : coercion =
@@ -407,7 +411,7 @@ let rec hastype (env : int list) (t : ML.term) (w : variable) : F.nominal_term c
      let ty = Inferno.Option.map (annotation_to_variable true bound_env) ty in
 
       (* Construct a ``let'' constraint. *)
-      let1 x ty (hastype bound_env t)
+      let1 x ty (is_gval t) (hastype bound_env t)
         (hastype env u w)
       <$$> fun (t, a, t', u') ->
       (* [a] are the type variables that we must introduce (via Lambda-abstractions)

--- a/client/Client.ml
+++ b/client/Client.ml
@@ -466,6 +466,7 @@ exception Unify = Solver.Unify
 exception UnifySkolem = Solver.UnifySkolem
 exception UnifyMono = Solver.UnifyMono
 exception Cycle = Solver.Cycle
+exception MismatchedQuantifiers = Solver.MismatchedQuantifiers
 
 let translate (t : ML.term) : F.nominal_term =
   solve false (

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -1180,6 +1180,19 @@ let fml_let_annot_6 =
   }
 
 (*
+   term: let (f : ∀ a. ∀ a. a → a) = λx.x in 1
+   type: Int
+*)
+let fml_let_annot_6_quantifier_shadowing =
+  { name = "let_annot_6_quantifier_shadowing"
+  ; term = ML.Let ( "f"
+                  , Some (TyForall(1, TyForall (1, TyArrow (TyVar 1, TyVar 1))))
+                  , abs "x" x
+                  , one)
+  ; typ = Some TyInt
+  }
+
+(*
    term: let (f : ∀ a. ∀ b. b → b) = id in 1
    type: Int
 *)
@@ -1188,6 +1201,20 @@ let fml_let_annot_7 =
   ; term = (fml_id)
            (ML.Let ( "f"
                    , Some (TyForall(1, TyForall (2, TyArrow (TyVar 2, TyVar 2))))
+                   , id
+                   , one))
+  ; typ = Some TyInt
+  }
+
+(*
+   term: let (f : ∀ a. ∀ a. a → a) = id in 1
+   type: Int
+*)
+let fml_let_annot_7_quantifier_shadowing =
+  { name = "let_annot_7_quantifier_shadowing"
+  ; term = (fml_id)
+           (ML.Let ( "f"
+                   , Some (TyForall(1, TyForall (1, TyArrow (TyVar 1, TyVar 1))))
                    , id
                    , one))
   ; typ = Some TyInt
@@ -1207,11 +1234,19 @@ let fml_let_annot_8 =
   ; typ = None
   }
 
-(* JSTOLAREK: once let_annot_6 - let_annot_8 work as expected I need to add
-   three more tests that are identical except for annotation on `f`, which
-   should be `∀ a. ∀ a. a → a` instead of currently used `∀ a. ∀ b. b → b`.
-   This will test shadowing and ensure that duplicate identifiers are not
-   removed. *)
+(*
+   term: let (f : ∀ a. ∀ a. a → a) = ~id in 1
+   type: X
+*)
+let fml_let_annot_8_quantifier_shadowing =
+  { name = "let_annot_8_quantifier_shadowing"
+  ; term = (fml_id)
+           (ML.Let ( "f"
+                   , Some (TyForall(1, TyForall (1, TyArrow (TyVar 1, TyVar 1))))
+                   , frozen "id"
+                   , one))
+  ; typ = None
+  }
 
 (*
    term: let (f : ∀ a. a → Bool) = λ(x:Int).x = x in 1
@@ -1727,8 +1762,11 @@ let () =
   test fml_let_annot_4;
   test fml_let_annot_5;
   test fml_let_annot_6;
+  test fml_let_annot_6_quantifier_shadowing;
   test fml_let_annot_7;
+  test fml_let_annot_7_quantifier_shadowing;
   test fml_let_annot_8;
+  test fml_let_annot_8_quantifier_shadowing;
   test fml_let_annot_9;
   test fml_let_annot_9_no_annot;
 

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -88,6 +88,9 @@ let print_type ty =
 let print_ml_term m =
   PPrint.(ToChannel.pretty 0.9 80 stdout (MLPrinter.print_term m ^^ hardline))
 
+let print_types tys =
+  PPrint.(ToChannel.pretty 0.9 80 stdout (separate comma (List.map FPrinter.print_type tys) ^^ hardline))
+
 let translate log t =
   try
     Result.WellTyped (Client.translate t)
@@ -134,9 +137,9 @@ let translate log t =
      log_action log (fun () ->
          Printf.fprintf stdout "Type error: Quantifiers in let annotation don't matched inferred ones.\n";
          Printf.fprintf stdout "Expected:\n";
-                     (* JSTOLAREK: TODO print quantifiers *)
-         Printf.fprintf stdout "Inferred:\n"
-                     (* JSTOLAREK: TODO print quantifiers *)
+         print_types xs;
+         Printf.fprintf stdout "Inferred:\n";
+         print_types ys
        );
      IllTyped
   (* JSTOLAREK: other exceptions are thrown due to bugs in the implementation.

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -3,7 +3,7 @@ open F
 open Result
 
 let verbose =
-  true
+  false
 
 (* -------------------------------------------------------------------------- *)
 
@@ -89,7 +89,9 @@ let print_ml_term m =
   PPrint.(ToChannel.pretty 0.9 80 stdout (MLPrinter.print_term m ^^ hardline))
 
 let print_types tys =
-  PPrint.(ToChannel.pretty 0.9 80 stdout (separate comma (List.map FPrinter.print_type tys) ^^ hardline))
+  PPrint.(ToChannel.pretty 0.9 80 stdout
+     (lbracket ^^ separate comma (List.map FPrinter.print_type tys) ^^ rbracket
+      ^^ hardline))
 
 let translate log t =
   try
@@ -137,9 +139,9 @@ let translate log t =
      log_action log (fun () ->
          Printf.fprintf stdout "Type error: Quantifiers in let annotation don't matched inferred ones.\n";
          Printf.fprintf stdout "Expected:\n";
-         print_types xs;
+         print_types ys;
          Printf.fprintf stdout "Inferred:\n";
-         print_types ys
+         print_types xs
        );
      IllTyped
   (* JSTOLAREK: other exceptions are thrown due to bugs in the implementation.
@@ -1647,7 +1649,6 @@ let fml_e3_dot_no_lambda_sig =
   }
 
 let () =
-(*
   test env_test;
   (* PLDI paper examples *)
   test a1;
@@ -1704,7 +1705,7 @@ let () =
   test fml_let_annot_1;
   test fml_let_annot_2;
   test fml_let_annot_3;
-  known_broken_test fml_let_annot_4;
+  test fml_let_annot_4;
   test fml_let_annot_5;
   test fml_let_annot_6;
   test fml_let_annot_7;
@@ -1747,7 +1748,5 @@ let () =
   test fml_mono_gen_test1;
   test fml_mono_gen_test2;
   test fml_e3_dot_no_lambda_sig
-*)
-  test fml_let_annot_8
 
 let () = print_summary_and_exit ()

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -1700,7 +1700,7 @@ let () =
   test fml_let_annot_1;
   test fml_let_annot_2;
   test fml_let_annot_3;
-  known_broken_test fml_let_annot_4;
+  test fml_let_annot_4;
   test fml_let_annot_5;
   test fml_let_annot_6;
   test fml_let_annot_7;

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -1704,7 +1704,7 @@ let () =
   test fml_let_annot_1;
   test fml_let_annot_2;
   test fml_let_annot_3;
-  test fml_let_annot_4;
+  known_broken_test fml_let_annot_4;
   test fml_let_annot_5;
   test fml_let_annot_6;
   test fml_let_annot_7;

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -806,6 +806,22 @@ let f9 =
   ; typ  = Some (TyProduct (TyInt, TyBool))
   }
 
+(* example            : F9
+   term               : let f : ∀ b. ((∀ a. a → a) → b) → b = revapp ~id in f poly
+   inferred type      : Int × Bool
+   type in PLDI paper : Int × Bool
+   Note               : this one is absert from PLDI paper
+ *)
+let f9_annot =
+  { name = "F9_annot"
+  ; term = (fml_revapp << fml_id << fml_poly)
+           (ML.Let ( "f"
+                   , Some (TyForall (2, TyArrow (TyForall (1, TyArrow (TyVar 1, TyVar 1)) , TyVar 2) ))
+                   , app (var "revapp") (frozen "id")
+                   , app (var "f") poly))
+  ; typ  = Some (TyProduct (TyInt, TyBool))
+  }
+
 (* example            : F10†
    term               : choose id (λ(x : ∀ a. a → a). $(auto' ~x))
    inferred type      : (∀ a. a → a) → (∀ a. a → a)
@@ -1675,6 +1691,7 @@ let () =
   test e3_dot;
 
   test f9;
+  test f9_annot;
   test f10_dagger;
 
   test bad1;

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -3,7 +3,7 @@ open F
 open Result
 
 let verbose =
-  false
+  true
 
 (* -------------------------------------------------------------------------- *)
 
@@ -1647,6 +1647,7 @@ let fml_e3_dot_no_lambda_sig =
   }
 
 let () =
+(*
   test env_test;
   (* PLDI paper examples *)
   test a1;
@@ -1746,5 +1747,7 @@ let () =
   test fml_mono_gen_test1;
   test fml_mono_gen_test2;
   test fml_e3_dot_no_lambda_sig
+*)
+  test fml_let_annot_8
 
 let () = print_summary_and_exit ()

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -130,6 +130,15 @@ let translate log t =
      log_action log (fun () ->
          Printf.fprintf stdout  "Type error: Violated monomorphism constraint\n" );
      IllTyped
+  | Client.MismatchedQuantifiers (xs, ys) ->
+     log_action log (fun () ->
+         Printf.fprintf stdout "Type error: Quantifiers in let annotation don't matched inferred ones.\n";
+         Printf.fprintf stdout "Expected:\n";
+                     (* JSTOLAREK: TODO print quantifiers *)
+         Printf.fprintf stdout "Inferred:\n"
+                     (* JSTOLAREK: TODO print quantifiers *)
+       );
+     IllTyped
   (* JSTOLAREK: other exceptions are thrown due to bugs in the implementation.
      I'm catching them here to simplify testing by not having to comment out
      failing test cases.  No exceptions should ever happen in a correct
@@ -1695,7 +1704,7 @@ let () =
   test fml_let_annot_5;
   test fml_let_annot_6;
   test fml_let_annot_7;
-  known_broken_test fml_let_annot_8;
+  test fml_let_annot_8;
   test fml_let_annot_9;
   test fml_let_annot_9_no_annot;
 

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -816,7 +816,9 @@ let f9_annot =
   { name = "F9_annot"
   ; term = (fml_revapp << fml_id << fml_poly)
            (ML.Let ( "f"
-                   , Some (TyForall (2, TyArrow (TyForall (1, TyArrow (TyVar 1, TyVar 1)) , TyVar 2) ))
+                   , Some (TyForall (2, TyArrow (TyArrow
+                             (TyForall (1, TyArrow (TyVar 1, TyVar 1)),
+                           TyVar 2), TyVar 2) ))
                    , app (var "revapp") (frozen "id")
                    , app (var "f") poly))
   ; typ  = Some (TyProduct (TyInt, TyBool))

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -806,8 +806,7 @@ let f9 =
   ; typ  = Some (TyProduct (TyInt, TyBool))
   }
 
-(* example            : F9
-   term               : let f : ∀ b. ((∀ a. a → a) → b) → b = revapp ~id in f poly
+(* term               : let f : ∀ b. ((∀ a. a → a) → b) → b = revapp ~id in f poly
    inferred type      : Int × Bool
    type in PLDI paper : Int × Bool
    Note               : this one is absert from PLDI paper

--- a/src/Generalization.ml
+++ b/src/Generalization.ml
@@ -318,11 +318,16 @@ let freshen_nested_quantifiers state { quantifiers; body } =
 
 exception MismatchedQuantifiers of U.variable list * U.variable list
 
-let assert_variables_equal (xs : U.variable list) (ys : U.variable list) :
+let rec variable_mem (v : U.variable) (xs : U.variable list) : bool =
+  match xs with
+  | [] -> false
+  | x :: xs -> U.id v == U.id x || variable_mem v xs
+
+let assert_variables_subset (xs : U.variable list) (ys : U.variable list) :
       U.variable list =
-  if (List.length xs != List.length ys) then
+  let is_subset = List.for_all (fun x -> variable_mem x ys) xs in
+  if (not is_subset) then
     raise (MismatchedQuantifiers (xs, ys));
-     (* JSTOLAREK: TODO test equality element by element *)
   xs
 
 (* -------------------------------------------------------------------------- *)

--- a/src/Generalization.ml
+++ b/src/Generalization.ml
@@ -318,16 +318,11 @@ let freshen_nested_quantifiers state { quantifiers; body } =
 
 exception MismatchedQuantifiers of U.variable list * U.variable list
 
-let rec variable_mem (v : U.variable) (xs : U.variable list) : bool =
-  match xs with
-  | [] -> false
-  | x :: xs -> U.id v == U.id x || variable_mem v xs
-
-let assert_variables_subset (xs : U.variable list) (ys : U.variable list) :
+let assert_variables_equal (xs : U.variable list) (ys : U.variable list) :
       U.variable list =
-  let is_subset = List.for_all (fun x -> variable_mem x ys) xs in
-  if (not is_subset) then
+  if (List.length xs != List.length ys) then
     raise (MismatchedQuantifiers (xs, ys));
+     (* JSTOLAREK: TODO test equality element by element *)
   xs
 
 (* -------------------------------------------------------------------------- *)

--- a/src/Generalization.ml
+++ b/src/Generalization.ml
@@ -318,12 +318,11 @@ let freshen_nested_quantifiers state { quantifiers; body } =
 
 exception MismatchedQuantifiers of U.variable list * U.variable list
 
-let assert_variables_equal (xs : U.variable list) (ys : U.variable list) :
-      U.variable list =
+let assert_variables_equal (xs : U.variable list) (ys : U.variable list) =
   if (List.length xs != List.length ys) then
     raise (MismatchedQuantifiers (xs, ys));
-     (* JSTOLAREK: TODO test equality element by element *)
-  xs
+  List.iter2 (fun x y -> if U.id x != U.id y
+                         then raise (MismatchedQuantifiers (xs, ys))) xs ys
 
 (* -------------------------------------------------------------------------- *)
 

--- a/src/Generalization.ml
+++ b/src/Generalization.ml
@@ -316,6 +316,15 @@ let freshen_nested_quantifiers state { quantifiers; body } =
   ; body        = copy toplevel_qs body }
 
 
+exception MismatchedQuantifiers of U.variable list * U.variable list
+
+let assert_variables_equal (xs : U.variable list) (ys : U.variable list) :
+      U.variable list =
+  if (List.length xs != List.length ys) then
+    raise (MismatchedQuantifiers (xs, ys));
+     (* JSTOLAREK: TODO test equality element by element *)
+  xs
+
 (* -------------------------------------------------------------------------- *)
 
 (* Debugging utilities. *)

--- a/src/Generalization.mli
+++ b/src/Generalization.mli
@@ -98,7 +98,7 @@ module Make (S : STRUCTURE) (U : UNIFIER with type 'a structure = 'a S.structure
   val drop_unused_quantifiers       : scheme -> scheme
 
   exception MismatchedQuantifiers of variable list * variable list
-  val assert_variables_equal : variable list -> variable list -> variable list
+  val assert_variables_equal : variable list -> variable list -> unit
 
   (* [enter] updates the current state by pushing a new [CLet] construct. The
      the hole is replaced with [let exists vs. hole in ...], where the list

--- a/src/Generalization.mli
+++ b/src/Generalization.mli
@@ -97,6 +97,9 @@ module Make (S : STRUCTURE) (U : UNIFIER with type 'a structure = 'a S.structure
   val freshen_nested_quantifiers    : state -> scheme -> scheme
   val drop_unused_quantifiers       : scheme -> scheme
 
+  exception MismatchedQuantifiers of variable list * variable list
+  val assert_variables_equal : variable list -> variable list -> variable list
+
   (* [enter] updates the current state by pushing a new [CLet] construct. The
      the hole is replaced with [let exists vs. hole in ...], where the list
      [vs] of young variables is empty. This function is used when entering the

--- a/src/Generalization.mli
+++ b/src/Generalization.mli
@@ -98,7 +98,7 @@ module Make (S : STRUCTURE) (U : UNIFIER with type 'a structure = 'a S.structure
   val drop_unused_quantifiers       : scheme -> scheme
 
   exception MismatchedQuantifiers of variable list * variable list
-  val assert_variables_equal : variable list -> variable list -> variable list
+  val assert_variables_subset : variable list -> variable list -> variable list
 
   (* [enter] updates the current state by pushing a new [CLet] construct. The
      the hole is replaced with [let exists vs. hole in ...], where the list

--- a/src/Generalization.mli
+++ b/src/Generalization.mli
@@ -98,7 +98,7 @@ module Make (S : STRUCTURE) (U : UNIFIER with type 'a structure = 'a S.structure
   val drop_unused_quantifiers       : scheme -> scheme
 
   exception MismatchedQuantifiers of variable list * variable list
-  val assert_variables_subset : variable list -> variable list -> variable list
+  val assert_variables_equal : variable list -> variable list -> variable list
 
   (* [enter] updates the current state by pushing a new [CLet] construct. The
      the hole is replaced with [let exists vs. hole in ...], where the list

--- a/src/SolverHi.ml
+++ b/src/SolverHi.ml
@@ -364,6 +364,7 @@ exception Unify of O.ty * O.ty
 exception UnifySkolem of O.ty * O.ty
 exception Cycle of O.ty
 exception UnifyMono
+exception MismatchedQuantifiers of O.ty list * O.ty list
 (* END EXC *)
 
 (* BEGIN SOLVE *)
@@ -395,6 +396,9 @@ let solve rectypes (rc, k) =
       raise (Cycle (decode v))
   | Lo.UnifyMono ->
      raise (UnifyMono)
+  | Lo.MismatchedQuantifiers (xs, ys) ->
+     let decode = new_decoder true (* cyclic decoder *) in
+     raise (MismatchedQuantifiers (List.map decode xs, List.map decode ys))
   end;
   (* Create a suitable decoder. *)
   let decode = new_decoder rectypes in

--- a/src/SolverHi.ml
+++ b/src/SolverHi.ml
@@ -278,11 +278,11 @@ let letn xs f1 (rc2, k2) =
   (* For each term variable [x], create a fresh type variable [v], as in
      [CExist]. Also, create an uninitialized scheme hook, which will receive
      the type scheme of [x] after the solver runs. *)
-  let xvss = List.map (fun (x, ty) ->
+  let xvss = List.map (fun (x, ty, is_gval) ->
     let v = match ty with
       | None   -> fresh None
       | Some v -> v in
-    x, v, WriteOnceRef.create()
+    x, v, is_gval, WriteOnceRef.create()
   ) xs in
   (* Pass the vector of type variables to the user-supplied function [f1], as in
      [CExist].  These are fresh variables that we can later check against
@@ -300,7 +300,7 @@ let letn xs f1 (rc2, k2) =
     let generalizable =
       List.map decode_variable (WriteOnceRef.get generalizable_hook)
     and ss =
-      List.map (fun (_, _, scheme_hook) ->
+      List.map (fun (_, _, _, scheme_hook) ->
         decode_scheme decode (WriteOnceRef.get scheme_hook)
       ) xvss
     in
@@ -320,8 +320,8 @@ let single xs =
 
 (* [let1] is a special case of [letn], where only one term variable is bound. *)
 
-let let1 x ty f1 c2 =
-  letn [ x, ty ] (fun vs -> f1 (single vs)) c2 <$$>
+let let1 x ty is_gval f1 c2 =
+  letn [ x, ty, is_gval ] (fun vs -> f1 (single vs)) c2 <$$>
   fun (ss, generalizable, v1, v2) -> (single ss, generalizable, v1, v2)
 
 (* [let0] is a special case of [letn], where no term variable is bound, and

--- a/src/SolverHi.mli
+++ b/src/SolverHi.mli
@@ -158,7 +158,7 @@ module Make
        [\Lambda vs.a1].
      - the value [a1] produced by the constraint [c1].
      - the value [a2] produced by the constraint [c2]. *)
-  val let1: tevar -> variable option -> (variable -> 'a co) -> 'b co ->
+  val let1: tevar -> variable option -> bool -> (variable -> 'a co) -> 'b co ->
             (ty * tyvar list * 'a * 'b) co
 
   (* END HI *)
@@ -172,7 +172,7 @@ module Make
      [vs] to a constraint. The [i]-th term variable, [x_i], ends up bound to the
      constraint abstraction of the [i]-th type variable in [c_1], which one could
      write [\lambda v_i.c_1]. *)
-  val letn: (tevar * variable option) list -> (variable list -> 'a co) -> 'b co ->
+  val letn: (tevar * variable option * bool) list -> (variable list -> 'a co) -> 'b co ->
             (ty list * tyvar list * 'a * 'b) co
 
   (* BEGIN HI *)

--- a/src/SolverHi.mli
+++ b/src/SolverHi.mli
@@ -201,6 +201,7 @@ module Make
   exception UnifySkolem of ty * ty
   exception Cycle of ty
   exception UnifyMono
+  exception MismatchedQuantifiers of ty list * ty list
   val solve: bool -> 'a co -> 'a
 
 (* END *)

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -122,6 +122,7 @@ exception Unify = U.Unify
 exception UnifySkolem = U.UnifySkolem
 exception UnifyMono = U.UnifyMono
 exception Cycle = U.Cycle
+exception MismatchedQuantifiers = G.MismatchedQuantifiers
 
 let solve (rectypes : bool) (c : rawco) : unit =
 
@@ -283,10 +284,16 @@ let solve (rectypes : bool) (c : rawco) : unit =
                 U.unify (G.body annotation_scheme) (G.body s); (* See #2 *)
                 debug_unify_after (G.body annotation_scheme);
                 List.iter U.unskolemize (G.quantifiers annotation_scheme);
+                let generalizable =
+                  if is_gval
+                  then G.quantifiers annotation_scheme
+                  else G.assert_variables_equal generalizable
+                           (G.quantifiers annotation_scheme) in
+
                 (* When a type annotation is present we discard generalizable
                    variables from the generalization engine and use quantifiers
                    from the provided type signature. *)
-                annotation_scheme :: ss, G.quantifiers annotation_scheme
+                annotation_scheme :: ss, generalizable
               end
             else
                 s :: ss, generalizable

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -287,7 +287,7 @@ let solve (rectypes : bool) (c : rawco) : unit =
                 let generalizable =
                   if is_gval
                   then G.quantifiers annotation_scheme
-                  else G.assert_variables_subset generalizable
+                  else G.assert_variables_equal generalizable
                            (G.quantifiers annotation_scheme) in
 
                 (* When a type annotation is present we discard generalizable

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -273,7 +273,10 @@ let solve (rectypes : bool) (c : rawco) : unit =
               begin
                 G.register_signatures state annotation;
                 Debug.print (nest 2
-                  (string "Let-binder with type annotation:" ^^ hardline ^^
+                  ((if is_gval
+                    then string "Generalizable let-binder "
+                    else string "Let-binder ") ^^
+                   string "with type annotation:" ^^ hardline ^^
                    string "Annotation: " ^^ print_var annotation ^^ hardline ^^
                    string "Inferred  : " ^^ print_scheme s) );
                 let annotation_scheme = G.scheme annotation in

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -287,7 +287,7 @@ let solve (rectypes : bool) (c : rawco) : unit =
                 let generalizable =
                   if is_gval
                   then G.quantifiers annotation_scheme
-                  else G.assert_variables_equal generalizable
+                  else G.assert_variables_subset generalizable
                            (G.quantifiers annotation_scheme) in
 
                 (* When a type annotation is present we discard generalizable

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -290,7 +290,7 @@ let solve (rectypes : bool) (c : rawco) : unit =
                   else begin
                       G.assert_variables_equal (G.quantifiers s)
                         (G.quantifiers annotation_scheme);
-                      [] end in
+                      generalizable end in
 
                 (* When a type annotation is present we discard generalizable
                    variables from the generalization engine and use quantifiers

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -287,8 +287,10 @@ let solve (rectypes : bool) (c : rawco) : unit =
                 let generalizable =
                   if is_gval
                   then G.quantifiers annotation_scheme
-                  else G.assert_variables_equal generalizable
-                           (G.quantifiers annotation_scheme) in
+                  else begin
+                      G.assert_variables_equal (G.quantifiers s)
+                        (G.quantifiers annotation_scheme);
+                      [] end in
 
                 (* When a type annotation is present we discard generalizable
                    variables from the generalization engine and use quantifiers

--- a/src/SolverLo.mli
+++ b/src/SolverLo.mli
@@ -94,7 +94,7 @@ module Make
        [vs?] is filled with a list of type variables that must be universally
        quantified in the left-hand side of the [let] construct so as to be in
        scope when [C1] is decoded. *)
-  | CLet of (tevar * variable * ischeme WriteOnceRef.t) list
+  | CLet of (tevar * variable * bool * ischeme WriteOnceRef.t) list
         * variable list
         * rawco
         * rawco

--- a/src/SolverLo.mli
+++ b/src/SolverLo.mli
@@ -116,6 +116,7 @@ module Make
   exception UnifySkolem of variable * variable
   exception UnifyMono
   exception Cycle of variable
+  exception MismatchedQuantifiers of variable list * variable list
   val solve: bool -> rawco -> unit
 
   (* ---------------------------------------------------------------------- *)


### PR DESCRIPTION
Here's a preliminary patch that fixes #15. At this point all the examples work, although I admit I'm not entirely sure what I implemented from a theoretical standpoint, hence a PR that we can discuss before merging. The key logic of this patch is in SolverLo, lines 290-297. Everything else is fallout and examples.

# Examples

Examples are well-typed, unless noted otherwise

  1. `let (f : ∀ a. a → a) = λx.x in ...`
  2. `let (f : ∀ a. a → a) = id in ...`
  3. `let (f : ∀ a. a → a) = ~id in ...`
  4. `let (f : ∀ a. ∀ b. b → b) = λx.x in ...`
  5. `let (f : ∀ a. ∀ b. b → b) = id in ...`
  6. `let (f : ∀ a. ∀ b. b → b) = ~id in ...` **ill-typed**

# Solution

From @frank-emrich's explanation [here](https://github.com/jstolarek/inferno/issues/15#issuecomment-739395595) my understanding is that getting this right requires tracking whether we are dealing with a GVal or not. So I'm recording that information inside CLet and using it when checking inferred scheme against quantifiers. In my patch applications and frozen variables are considered non-generalizable and everything else is generalizable. There are two things that we need to get right when dealing with annotations:

  1. Ensure that annotation is an instance of the inferred type
  2. Determine the set of generalizable variables - these will be Λ-abstracted in the System F term. Note that quantifiers are not synonymous with generalizable variables. In example (3) above the quantifiers are `[a]` and generalizable variables are empty set.

First check is performed by unifying bodies of annotation and inferred type and is not affected by quantifiers in any way. The second check is now performed in following way:

  1. If we are dealing with a generalizable expression then use the quantifiers from the type annotation. This ensures correct treatment of redundant quantifiers, which we must Λ-abstract.
  2. If we are dealing with a non-generalizable expression we ensure that the inferred and annotated quantifiers are identical  - ensuring this allows to reject example (6) above. If that is the case we Λ-abstract generalizable variables discovered by generalization engine. Note that when we add the binder to the environment we retain it's original signature - quantifiers and generalizable variables are distinct.

When dealing with let bindings without signatures we keep the set of generalizable variables, regardless of whether we're dealing with GVal or not.

Now I get to the point where I am a bit puzzled. The above approach is not synonymous with implementing value restriction, even though we are relying on distinction between GVal and non-GVal expressions. This feels bizarre and I'm not yet sure how it affects theoretical presentation of the system and its equivalence with PLDI system. I'm pondering whether it's worth to bite the bullet and implement the value restriction. Would that simplify theoretical presentation of the paper if we wanted to show equivalence with the PLDI system? Thoughts welcome.

PS. I know naming the branch with this patch `value_restriction` is confusing, but I thought I'll end up implementing a proper value restriction when I started.