### PR TITLE
Use monomorphic let constraints instead of def

### DIFF
--- a/client/Client.ml
+++ b/client/Client.ml
@@ -340,13 +340,17 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
        begin
          match ann with
          | None ->
-               exist (fun v1 ->
+               (*exist (fun v1 ->*)
+                   let1_mono x None false (hastype env t) (hastype env u w)
+
+(*
                    hastype env t v1 ^&
                    (* order of constraints important here! *)
                    mono_inst x v1 ^&
                    def x v1 (hastype env u w)
-            ) <$$>
-                 fun (_ty', (t', ((), u'))) ->
+*)
+             <$$>
+                 fun (_, _, t', u') ->
                  F.Let (x, t', u')
          | Some ty ->
             (* This implements C-LetAscribe constraint generation rule.
@@ -356,12 +360,10 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
                registered with the generalisation engine before being used.
                Registration is carried out by `def`, hence it is important it
                comes first. *)
-            exist ?v:(Some (annotation_to_variable false env ty)) (fun v1 ->
-                    def x v1 (hastype env u w) ^&
-                      hastype bound_env t v1
-              ) <$$>
-              fun (_ty', (u', t')) ->
-              F.Let (x, t', u')
+            let1_mono x (Some (annotation_to_variable true env ty)) false (hastype bound_env t) (hastype env u w)
+             <$$>
+                 fun (_, _, t', u') ->
+                 F.Let (x, t', u')
        end
      else begin
       (* Construct a ``let'' constraint. *)

--- a/client/Client.ml
+++ b/client/Client.ml
@@ -382,6 +382,9 @@ exception Cycle = Solver.Cycle
 exception MismatchedQuantifiers = Solver.MismatchedQuantifiers
 
 let translate (value_restriction : bool) (t : ML.term) : F.nominal_term =
+  let let0 = if value_restriction && not (is_gval t)
+             then let0_mono
+             else let0_gen in
   solve false (
     let0 (exist_ (hastype value_restriction [] t)) <$$> fun (vs, t) ->
     (* [vs] are the binders that we must introduce *)

--- a/client/Client.ml
+++ b/client/Client.ml
@@ -276,35 +276,10 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
       F.Var x
 
     (* Abstraction. *)
-  | ML.Abs (x, None, u) ->
-
-      (* We do not know a priori what the domain and codomain of this function
-         are, so we must infer them. We introduce two type variables to stand
-         for these unknowns. *)
-      exist (fun v1 ->
-        (* Here, we could use [exist_], because we do not need [ty2]. I refrain
-           from using it, just to simplify the paper. *)
-        exist (fun v2 ->
-          (* [w] must be the function type [v1 -> v2]. *)
-          (* Here, we could use [^^], instead of [^&], so as to avoid building
-             a useless pair. I refrain from using it, just to simplify the paper. *)
-          w --- arrow v1 v2 ^&
-          (* Under the assumption that [x] has type [domain], the term [u] must
-             have type [codomain]. *)
-          let1_mono x None false (fun v -> v -- v1) (hastype env u v2)
-
-        )
-      ) <$$> fun (ty1, (_ty2, ((), (_, _, (), u')))) ->
-      (* Once these constraints are solved, we obtain the translated function
-         body [u']. There remains to construct an explicitly-typed abstraction
-         in the target calculus. *)
-      F.Abs (x, ty1, u')
-
   | ML.Abs (x, ann, u) ->
 
      (* Construct an existential variable with structure defined by the type
         annotation. *)
-
       let ty = Inferno.Option.map (annotation_to_variable false env) ann in
 
       exist ?v:ty (fun v1 ->

--- a/client/Client.ml
+++ b/client/Client.ml
@@ -289,13 +289,12 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
           (* Here, we could use [^^], instead of [^&], so as to avoid building
              a useless pair. I refrain from using it, just to simplify the paper. *)
           w --- arrow v1 v2 ^&
-          (* Monomorphic predicate on an unannotated binder *)
-          mono x v1 ^&
           (* Under the assumption that [x] has type [domain], the term [u] must
              have type [codomain]. *)
-          def x v1 (hastype env u v2)
+          let1_mono x None false (fun v -> v -- v1) (hastype env u v2)
+
         )
-      ) <$$> fun (ty1, (_ty2, ((), ((), u')))) ->
+      ) <$$> fun (ty1, (_ty2, ((), (_, _, (), u')))) ->
       (* Once these constraints are solved, we obtain the translated function
          body [u']. There remains to construct an explicitly-typed abstraction
          in the target calculus. *)

--- a/client/Client.ml
+++ b/client/Client.ml
@@ -322,6 +322,7 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
          | Some ann -> let (qs, _) = O.to_scheme ann in List.append qs env
          | _        -> env in
 
+     (* Convert type annotation to an internal representation *)
      let ty = Inferno.Option.map (annotation_to_variable true env) ann in
 
      (* Pick appropriate function for constructing let constraint *)

--- a/client/Client.ml
+++ b/client/Client.ml
@@ -84,6 +84,7 @@ module S = struct
        parens (f fuel t1 ^^ space ^^ string "->" ^^ space ^^ f fuel t2)
     | TyProduct (t1, t2) ->
        parens (f fuel t1 ^^ string "×" ^^ f fuel t2)
+    | TyForall  ([],  t) -> f fuel t
     | TyForall  (qs,  t) ->
        string "forall " ^^ lbracket ^^
        separate (comma ^^ space) (List.map (fun q -> f fuel q) qs) ^^

--- a/client/Client.ml
+++ b/client/Client.ml
@@ -300,14 +300,14 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
          in the target calculus. *)
       F.Abs (x, ty1, u')
 
-  | ML.Abs (x, Some ty, u) ->
+  | ML.Abs (x, ann, u) ->
 
      (* Construct an existential variable with structure defined by the type
         annotation. *)
 
-      let ann = annotation_to_variable false env ty in
+      let ty = Inferno.Option.map (annotation_to_variable false env) ann in
 
-      exists_sig ann (fun v1 ->
+      exist ?v:ty (fun v1 ->
 
         (* Here, we could use [exist_], because we do not need [ty2]. I refrain
            from using it, just to simplify the paper. *)
@@ -319,7 +319,7 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
           w --- arrow v1 v2 ^&
           (* Under the assumption that [x] has type [domain], the term [u] must
              have type [codomain]. *)
-            let1_mono x (Some ann) false (fun v -> v -- v1) (hastype env u v2)
+            let1_mono x ty false (fun v -> v -- v1) (hastype env u v2)
         )
       ) <$$> fun (ty1, (_ty2, ((), (_, _, (), u')))) ->
         (* Once these constraints are solved, we obtain the translated function
@@ -381,7 +381,7 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
                registered with the generalisation engine before being used.
                Registration is carried out by `def`, hence it is important it
                comes first. *)
-            exists_sig (annotation_to_variable false env ty) (fun v1 ->
+            exist ?v:(Some (annotation_to_variable false env ty)) (fun v1 ->
                     def x v1 (hastype env u w) ^&
                       hastype bound_env t v1
               ) <$$>

--- a/client/Client.ml
+++ b/client/Client.ml
@@ -328,7 +328,7 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
      (* Pick appropriate function for constructing let constraint *)
      let let1 = if value_restriction && not (is_gval t)
                 then let1_mono
-                else let1 in
+                else let1_gen in
 
      let1 x ty (hastype bound_env t) (hastype env u w) <$$>
        fun (t, a, t', u') ->

--- a/client/Client.ml
+++ b/client/Client.ml
@@ -294,7 +294,7 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
           w --- arrow v1 v2 ^&
           (* Under the assumption that [x] has type [domain], the term [u] must
              have type [codomain]. *)
-            let1_mono x ty false (fun v -> v -- v1) (hastype env u v2)
+            let1_mono x ty (fun v -> v -- v1) (hastype env u v2)
         )
       ) <$$> fun (ty1, (_ty2, ((), (_, _, (), u')))) ->
         (* Once these constraints are solved, we obtain the translated function
@@ -330,7 +330,7 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
                 then let1_mono
                 else let1 in
 
-     let1 x ty (is_gval t) (hastype bound_env t) (hastype env u w) <$$>
+     let1 x ty (hastype bound_env t) (hastype env u w) <$$>
        fun (t, a, t', u') ->
        (* [a] are the type variables that we must introduce (via
           Lambda-abstractions) while type-checking [t']. [t] is a type of bound

--- a/client/Client.ml
+++ b/client/Client.ml
@@ -305,7 +305,9 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
      (* Construct an existential variable with structure defined by the type
         annotation. *)
 
-      exists_sig (annotation_to_variable false env ty) (fun v1 ->
+      let ann = annotation_to_variable false env ty in
+
+      exists_sig ann (fun v1 ->
 
         (* Here, we could use [exist_], because we do not need [ty2]. I refrain
            from using it, just to simplify the paper. *)
@@ -317,9 +319,9 @@ let rec hastype (value_restriction : bool) (env : int list) (t : ML.term)
           w --- arrow v1 v2 ^&
           (* Under the assumption that [x] has type [domain], the term [u] must
              have type [codomain]. *)
-          def x v1 (hastype env u v2)
+            let1_mono x (Some ann) false (fun v -> v -- v1) (hastype env u v2)
         )
-      ) <$$> fun (ty1, (_ty2, ((), u'))) ->
+      ) <$$> fun (ty1, (_ty2, ((), (_, _, (), u')))) ->
         (* Once these constraints are solved, we obtain the translated function
            body [u']. There remains to construct an explicitly-typed abstraction
            in the target calculus. *)

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -1130,7 +1130,7 @@ let fml_nested_forall_inst_1 =
    term : let (f : (∀ a. (∀ b. b → b) → a → a) → (∀ a. (∀ b. b → b) → a → a)) = id in
           let g = f $auto' in
           g ~id
-   type : ∀ a. a → a
+   type : [∀ a.] a → a
 *)
 let fml_nested_forall_inst_2 =
   { name = "nested_forall_inst_2"
@@ -1150,7 +1150,7 @@ let fml_nested_forall_inst_2 =
    term : let (f : ∀ a. ((∀ b. b → b) → a → a) → ((∀ b. b → b) → a → a)) = id in
           let g = f (id auto') in
           g ~id
-   type : ∀ a. a → a
+   type : [∀ a.] a → a
 *)
 let fml_nested_forall_inst_3 =
   { name = "nested_forall_inst_3"

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -1443,6 +1443,42 @@ let fml_quantifier_ordering_2 =
   }
 
 (*
+   term : let pair' : ∀ b a. a → b → (a × b) = ~pair in pair'
+   type : X
+*)
+let fml_quantifier_ordering_3 =
+  { name = "quantifier_ordering_3"
+  ; term = (fml_pair)
+           (ML.Let ( "pair'"
+                    , Some (TyForall (2, TyForall (1,
+                                     TyArrow (TyVar 1, TyArrow (TyVar 2,
+                                     TyProduct (TyVar 1, TyVar 2))))))
+                    , frozen "pair"
+                    , var "pair'"))
+  ; typ  = None
+  ; vres = true
+  }
+
+(*
+   term : let pair' : ∀ b a. a → b → (a × b) = pair in ~pair'
+   type : ∀ b a. a → b → (a × b)
+*)
+let fml_quantifier_ordering_4 =
+  { name = "quantifier_ordering_4"
+  ; term = (fml_pair)
+           (ML.Let ( "pair'"
+                    , Some (TyForall (2, TyForall (1,
+                                     TyArrow (TyVar 1, TyArrow (TyVar 2,
+                                     TyProduct (TyVar 1, TyVar 2))))))
+                    , var "pair"
+                    , frozen "pair'"))
+  ; typ  = Some (TyForall ((), TyForall ((),
+                                     TyArrow (TyVar 0, TyArrow (TyVar 1,
+                                     TyProduct (TyVar 0, TyVar 1))))))
+  ; vres = true
+  }
+
+(*
    term : let (x : (∀ a. a → a) → Int) = λ(f : ∀ a. a → a). f 1 in 1
    type : Int
    bugs : #2
@@ -1977,6 +2013,8 @@ let () =
 
   test fml_quantifier_ordering_1;
   test fml_quantifier_ordering_2;
+  test fml_quantifier_ordering_3;
+  test fml_quantifier_ordering_4;
 
   test fml_type_annotations_1;
   test fml_id_appl;

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -1368,7 +1368,7 @@ let fml_let_annot_9_no_annot =
    term: let f : ∀a b. a → b → b =
            let g : ∀ b. a → b → b = λy.λz.z in id ~g
          in f
-   type: ∀a b. a → b → b
+   type: None
    bug: #31
 *)
 let fml_let_annot_10 =
@@ -1382,7 +1382,7 @@ let fml_let_annot_10 =
                             , app id (frozen "g")
                             )
                    , f))
-  ; typ  = Some (TyForall ((), TyForall ((), TyArrow (TyArrow (TyVar 1, TyVar 0), TyVar 0))))
+  ; typ  = None
   ; vres = true
   }
 

--- a/client/Main.ml
+++ b/client/Main.ml
@@ -1809,7 +1809,7 @@ let fml_scoped_tyvars_1 =
   { name = "scoped_tyvars_1"
   ; term = (fml_id_int)
            (ML.Let ( "x"
-                  , Some (TyForall (1, TyArrow(TyArrow(TyVar 1, TyVar 1),TyArrow(TyVar 1, TyVar 1))))
+                  , Some (TyForall (1, TyArrow( TyArrow (TyVar 1, TyVar 1),TyArrow(TyVar 1, TyVar 1))))
                   , ML.Let ( "y"
                            , Some (TyArrow (TyVar 1, TyVar 1))
                            , abs "w" w

--- a/src/Debug.ml
+++ b/src/Debug.ml
@@ -1,4 +1,4 @@
-let enabled     = true
+let enabled     = false
 let hard        = true
 let print_ranks = true
 let fuel        = 8

--- a/src/Debug.ml
+++ b/src/Debug.ml
@@ -1,4 +1,4 @@
-let enabled     = false
+let enabled     = true
 let hard        = true
 let print_ranks = true
 let fuel        = 8

--- a/src/Generalization.ml
+++ b/src/Generalization.ml
@@ -351,7 +351,11 @@ let assert_variables_equal (xs : U.variable list) (ys : U.variable list) =
 (* Debugging utilities. *)
 
 let show_variable v =
-  Printf.printf "id = %d, rank = %d\n" (U.id v) (U.rank v); flush stdout
+  Printf.printf "id = %d, rank = %d" (U.id v) (U.rank v);
+  if (U.is_monomorphic v) then Printf.printf ", mono";
+  if (U.is_skolem v) then Printf.printf ", skolem";
+  Printf.printf "\n";
+  flush stdout
 
 let show_pool state k =
   Printf.printf "Pool %d:\n" k;

--- a/src/Generalization.ml
+++ b/src/Generalization.ml
@@ -354,6 +354,7 @@ let show_variable v =
   Printf.printf "id = %d, rank = %d" (U.id v) (U.rank v);
   if (U.is_monomorphic v) then Printf.printf ", mono";
   if (U.is_skolem v) then Printf.printf ", skolem";
+  if (U.is_representative v) then Printf.printf ", repr";
   Printf.printf "\n";
   flush stdout
 

--- a/src/Generalization.ml
+++ b/src/Generalization.ml
@@ -559,7 +559,11 @@ let exit rectypes state roots =
 
   let vs =
     List.filter (fun v ->
-      U.is_representative v && begin
+      begin
+        if U.rank v = generic then
+          (* A copy of this variable already visited, discard *)
+          false
+        else
         if U.rank v < state.young then begin
           register_at_rank state v;
           false

--- a/src/Generalization.ml
+++ b/src/Generalization.ml
@@ -645,8 +645,10 @@ let instantiate state { quantifiers; body } =
       end
   in
   (* Enforcing proper order of evaluation is crucial here *)
-  let quantifiers = List.map (copy true) quantifiers in
-  let body        = copy true body in
-  quantifiers, body
+  let quantifiers' = List.map (copy true) quantifiers in
+  let body         = copy true body in
+  List.iter2 (fun v v' -> U.set_monomorphic v' (U.is_monomorphic v))
+             quantifiers quantifiers';
+  quantifiers', body
 
 end

--- a/src/Generalization.mli
+++ b/src/Generalization.mli
@@ -95,6 +95,7 @@ module Make (S : STRUCTURE) (U : UNIFIER with type 'a structure = 'a S.structure
   (* JSTOLAREK: documentation outdated, this is now an inteligent constructor *)
 
   val scheme                        : variable -> scheme
+  val degenerate_scheme             : variable -> scheme
   val bound_quantifiers             : scheme -> variable list
   val unbound_quantifiers           : scheme -> variable list
   val unbound_tyvars                : scheme -> variable list

--- a/src/SolverHi.ml
+++ b/src/SolverHi.ml
@@ -156,9 +156,7 @@ let annotation_to_variable (generic_qs : bool) (env : int list) (t : O.ty) :
 (* Existential quantification. *)
 
 (* BEGIN EXIST *)
-let exist f =
-  (* Create a fresh unifier variable [v]. *)
-  let v = fresh None in
+let exist ?(v=fresh None) f =
   (* Pass [v] to the client. *)
   let rc, k = f v in
   (* Wrap the constraint [c] in an existential quantifier, *)
@@ -176,13 +174,6 @@ let exist f =
 
 let construct t f =
   let v = fresh (Some t) in
-  let rc, k = f v in
-  CExist (v, rc),
-  fun env ->
-    let decode = env in
-    (decode v, k env)
-
-let exists_sig v f =
   let rc, k = f v in
   CExist (v, rc),
   fun env ->

--- a/src/SolverHi.ml
+++ b/src/SolverHi.ml
@@ -297,7 +297,7 @@ let letn xs f1 (rc2, k2) =
      all generalizable variables in the left-hand side. *)
   let generalizable_hook = WriteOnceRef.create() in
   (* Build a [CLet] constraint. *)
-  CLet (xvss, vs, rc1, rc2, generalizable_hook),
+  CLet (CLetGen, xvss, vs, rc1, rc2, generalizable_hook),
   fun env ->
     (* In the decoding phase, read the write-once references, *)
     let decode = env in
@@ -351,7 +351,7 @@ include struct
 
 let ok rc =
   match rc with
-  | CLet (_, _, _, CTrue, _) ->
+  | CLet (_, _, _, _, CTrue, _) ->
       (* The argument of [solve] should be constructed by [let0]. *)
       true
   | _ ->

--- a/src/SolverHi.ml
+++ b/src/SolverHi.ml
@@ -312,8 +312,12 @@ let let1_mono x ty f1 c2 =
    the right-hand side is [CTrue]. We require using this form at the toplevel
    of every constraint. *)
 
-let let0 c1 =
+let let0_gen c1 =
   letn CLetGen [] (fun _ -> c1) (pure ()) <$$>
+  fun (_, generalizable, v1, ()) -> (generalizable, v1)
+
+let let0_mono c1 =
+  letn CLetMono [] (fun _ -> c1) (pure ()) <$$>
   fun (_, generalizable, v1, ()) -> (generalizable, v1)
 
 (* -------------------------------------------------------------------------- *)

--- a/src/SolverHi.ml
+++ b/src/SolverHi.ml
@@ -250,21 +250,6 @@ let frozen_instance x v =
 
 (* Constraint abstractions. *)
 
-(* The [CDef] form is so trivial that it deserves its own syntax. Viewing it
-   as a special case of [CLet] would be more costly (by a constant factor). *)
-
-let def x v (rc, k) =
-  CDef (x, v, rc),
-  k
-
-let mono x v =
-  PMono (x, v),
-  fun _env -> ()
-
-let mono_inst x v =
-  PMonoInst (x, v),
-  fun _env -> ()
-
 (* The general form of [CLet] involves two constraints, the left-hand side and
    the right-hand side, yet it defines a *family* of constraint abstractions,
    bound the term variables [xs]. *)

--- a/src/SolverHi.ml
+++ b/src/SolverHi.ml
@@ -258,11 +258,11 @@ let letn clet_type xs f1 (rc2, k2) =
   (* For each term variable [x], create a fresh type variable [v], as in
      [CExist]. Also, create an uninitialized scheme hook, which will receive
      the type scheme of [x] after the solver runs. *)
-  let xvss = List.map (fun (x, ty, is_gval) ->
+  let xvss = List.map (fun (x, ty) ->
     let v = match ty with
       | None   -> fresh None
       | Some v -> v in
-    x, v, is_gval, WriteOnceRef.create()
+    x, v, WriteOnceRef.create()
   ) xs in
   (* Pass the vector of type variables to the user-supplied function [f1], as in
      [CExist].  These are fresh variables that we can later check against
@@ -280,7 +280,7 @@ let letn clet_type xs f1 (rc2, k2) =
     let generalizable =
       List.map decode_variable (WriteOnceRef.get generalizable_hook)
     and ss =
-      List.map (fun (_, _, _, scheme_hook) ->
+      List.map (fun (_, _, scheme_hook) ->
         decode_scheme decode (WriteOnceRef.get scheme_hook)
       ) xvss
     in
@@ -300,12 +300,12 @@ let single xs =
 
 (* [let1] is a special case of [letn], where only one term variable is bound. *)
 
-let let1 x ty is_gval f1 c2 =
-  letn CLetGen [ x, ty, is_gval ] (fun vs -> f1 (single vs)) c2 <$$>
+let let1 x ty f1 c2 =
+  letn CLetGen [ x, ty ] (fun vs -> f1 (single vs)) c2 <$$>
   fun (ss, generalizable, v1, v2) -> (single ss, generalizable, v1, v2)
 
-let let1_mono x ty is_gval f1 c2 =
-  letn CLetMono [ x, ty, is_gval ] (fun vs -> f1 (single vs)) c2 <$$>
+let let1_mono x ty f1 c2 =
+  letn CLetMono [ x, ty ] (fun vs -> f1 (single vs)) c2 <$$>
   fun (ss, generalizable, v1, v2) -> (single ss, generalizable, v1, v2)
 
 (* [let0] is a special case of [letn], where no term variable is bound, and

--- a/src/SolverHi.ml
+++ b/src/SolverHi.ml
@@ -300,7 +300,7 @@ let single xs =
 
 (* [let1] is a special case of [letn], where only one term variable is bound. *)
 
-let let1 x ty f1 c2 =
+let let1_gen x ty f1 c2 =
   letn CLetGen [ x, ty ] (fun vs -> f1 (single vs)) c2 <$$>
   fun (ss, generalizable, v1, v2) -> (single ss, generalizable, v1, v2)
 

--- a/src/SolverHi.ml
+++ b/src/SolverHi.ml
@@ -114,9 +114,9 @@ let (^^) (rc1, k1) (rc2, k2) =
       Annotation on a let expression brings its quantifiers into scope in the
       bound term.  Variables in scope are tracked by the client and passed in
       as initial env to the function.  The extra flag determines whether these
-      quantifiers should be generic (for let expressins) or not (for lambdas).
+      quantifiers should be generic (for let expressions) or not (for lambdas).
       It is crucial that for lambda expressions we don't treat variables
-      introduced by quantifiers in a let signature as generic.
+      introduced by quantifiers in a signature as generic.
 
     * When traversing the body we must also carefully distinguish whether we
       generate generic or unregistered variables.  Starting at the top level we

--- a/src/SolverHi.mli
+++ b/src/SolverHi.mli
@@ -163,6 +163,9 @@ module Make
   val let1: tevar -> variable option -> bool -> (variable -> 'a co) -> 'b co ->
             (ty * tyvar list * 'a * 'b) co
 
+  val let1_mono: tevar -> variable option -> bool -> (variable -> 'a co) -> 'b co ->
+            (ty * tyvar list * 'a * 'b) co
+
   (* END HI *)
   (* [let0 c] has the same meaning as [c], but, like [let1], produces a list [vs]
      of the type variables that may appear in the result of [c]. The argument of
@@ -174,7 +177,7 @@ module Make
      [vs] to a constraint. The [i]-th term variable, [x_i], ends up bound to the
      constraint abstraction of the [i]-th type variable in [c_1], which one could
      write [\lambda v_i.c_1]. *)
-  val letn: (tevar * variable option * bool) list -> (variable list -> 'a co) -> 'b co ->
+  val letn: clet_type -> (tevar * variable option * bool) list -> (variable list -> 'a co) -> 'b co ->
             (ty list * tyvar list * 'a * 'b) co
 
   (* BEGIN HI *)

--- a/src/SolverHi.mli
+++ b/src/SolverHi.mli
@@ -95,15 +95,13 @@ module Make
      in an existential quantifier for [v]. This results in a constraint of type
      [ty * 'a], where the left-hand component of the pair, a decoded type, is
      the witness for [v]. *)
-  val exist:                            (variable -> 'a co) -> (ty * 'a) co
+  val exist: ?v:variable -> (variable -> 'a co) -> (ty * 'a) co
 
   (* END HI *)
   (* [construct t c] is analogous to [exist c], but additionally constrains
      the type variable [v] to be equal to the type [t]. So, it is really a
      way of constructing a variable that stands for a shallow term. *)
   val construct:  variable structure -> (variable -> 'a co) -> (ty * 'a) co
-
-  val exists_sig: variable -> (variable -> 'a co) -> (ty * 'a) co
 
   (* ---------------------------------------------------------------------- *)
 

--- a/src/SolverHi.mli
+++ b/src/SolverHi.mli
@@ -139,14 +139,6 @@ module Make
 
   (* Construction of constraint abstractions, a.k.a. generalization. *)
 
-  (* [def x v c] binds the term variable [x] to the trivial (monomorphic) type
-     scheme [v] in the constraint [c]. *)
-  val def: tevar -> variable -> 'a co -> 'a co
-
-  val mono: tevar -> variable -> unit co
-
-  val mono_inst: tevar -> variable -> unit co
-
   (* [let1 x c1 c2] binds the term variable [x] to the constraint abstraction
      [c1] in the constraint [c2]. (Technically, [c1] is a function of a fresh
      type variable to a constraint, as in [exist].) The resulting constraint

--- a/src/SolverHi.mli
+++ b/src/SolverHi.mli
@@ -150,10 +150,10 @@ module Make
        [\Lambda vs.a1].
      - the value [a1] produced by the constraint [c1].
      - the value [a2] produced by the constraint [c2]. *)
-  val let1: tevar -> variable option -> bool -> (variable -> 'a co) -> 'b co ->
+  val let1: tevar -> variable option -> (variable -> 'a co) -> 'b co ->
             (ty * tyvar list * 'a * 'b) co
 
-  val let1_mono: tevar -> variable option -> bool -> (variable -> 'a co) -> 'b co ->
+  val let1_mono: tevar -> variable option -> (variable -> 'a co) -> 'b co ->
             (ty * tyvar list * 'a * 'b) co
 
   (* END HI *)
@@ -167,7 +167,7 @@ module Make
      [vs] to a constraint. The [i]-th term variable, [x_i], ends up bound to the
      constraint abstraction of the [i]-th type variable in [c_1], which one could
      write [\lambda v_i.c_1]. *)
-  val letn: clet_type -> (tevar * variable option * bool) list -> (variable list -> 'a co) -> 'b co ->
+  val letn: clet_type -> (tevar * variable option) list -> (variable list -> 'a co) -> 'b co ->
             (ty list * tyvar list * 'a * 'b) co
 
   (* BEGIN HI *)

--- a/src/SolverHi.mli
+++ b/src/SolverHi.mli
@@ -160,7 +160,8 @@ module Make
   (* [let0 c] has the same meaning as [c], but, like [let1], produces a list [vs]
      of the type variables that may appear in the result of [c]. The argument of
      [run] should always be an application of [let0] -- see below. *)
-  val let0: 'a co  -> (tyvar list * 'a) co
+  val let0_gen: 'a co  -> (tyvar list * 'a) co
+  val let0_mono: 'a co  -> (tyvar list * 'a) co
 
   (* [letn xs c1 c2] binds [n] term variables [xs] to [n] constraint abstractions
      in the constaint [c2]. Here, [c1] is a function of [n] fresh type variables

--- a/src/SolverHi.mli
+++ b/src/SolverHi.mli
@@ -150,7 +150,7 @@ module Make
        [\Lambda vs.a1].
      - the value [a1] produced by the constraint [c1].
      - the value [a2] produced by the constraint [c2]. *)
-  val let1: tevar -> variable option -> (variable -> 'a co) -> 'b co ->
+  val let1_gen: tevar -> variable option -> (variable -> 'a co) -> 'b co ->
             (ty * tyvar list * 'a * 'b) co
 
   val let1_mono: tevar -> variable option -> (variable -> 'a co) -> 'b co ->

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -89,6 +89,10 @@ let print_schemes vs =
    but not in the high-level interface [SolverHi]. So, it could be easily
    modified if desired. *)
 
+type clet_type =
+  | CLetMono
+  | CLetGen
+
 type rawco =
   (* Constraints *)
   | CTrue
@@ -98,7 +102,8 @@ type rawco =
   | CInstance of tevar * variable * variable list WriteOnceRef.t
   | CFrozen   of tevar * variable
   | CDef of tevar * variable * rawco
-  | CLet of (tevar * variable * bool * ischeme WriteOnceRef.t) list
+  | CLet of clet_type
+        * (tevar * variable * bool * ischeme WriteOnceRef.t) list
         * variable list (* Proxy variables *)
         * rawco         (* Bound term *)
         * rawco         (* Let body *)
@@ -225,7 +230,7 @@ let solve (rectypes : bool) (c : rawco) : unit =
              print_scheme scheme);
        assert (G.all_generic_vars_bound scheme);
        Debug.print (string "Exiting scope of binding " ^^ print_tevar x)
-    | CLet (xvss, vs, c1, c2, generalizable_hook) ->
+    | CLet (clet_type, xvss, vs, c1, c2, generalizable_hook) ->
         (* Warn the generalization engine that we entering the left-hand side of
            a [let] construct. *)
         G.enter state;

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -74,8 +74,10 @@ let print_vars vs =
 
 let print_scheme scheme =
   let open PPrint in
-  string "forall " ^^ print_vars (G.quantifiers scheme) ^^ dot ^^ space ^^
-    print_var (G.body scheme)
+  match G.quantifiers scheme with
+  | [] -> print_var (G.body scheme)
+  | qs -> string "forall " ^^ print_vars qs ^^ dot ^^ space ^^
+            print_var (G.body scheme)
 
 let print_schemes vs =
   let open PPrint in

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -277,8 +277,6 @@ let solve (rectypes : bool) (c : rawco) : unit =
                    string "Inferred  : " ^^ print_scheme s) );
                 let annotation_scheme = G.scheme annotation in
                 List.iter U.skolemize (G.quantifiers annotation_scheme);
-                if (clet_type = CLetMono)
-                then List.iter U.monomorphize (G.quantifiers s);
                 debug_unify_before
                   (string "Unifying let annotation with inferred type of let body.")
                   (G.body annotation_scheme) (G.body s);

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -290,7 +290,6 @@ let solve (rectypes : bool) (c : rawco) : unit =
                       G.assert_variables_equal (G.quantifiers s)
                         (G.quantifiers annotation_scheme);
                       generalizable end in
-
                 (* When a type annotation is present we discard generalizable
                    variables from the generalization engine and use quantifiers
                    from the provided type signature. *)
@@ -299,12 +298,11 @@ let solve (rectypes : bool) (c : rawco) : unit =
             else
               begin
                 if (clet_type = CLetMono)
-                then List.iter U.monomorphize (G.unbound_tyvars s);
+                then List.iter U.monomorphize (G.unbound_tyvars s)
+                else List.iter U.unmonomorphize generalizable;
                 s :: ss, generalizable
-                end
+              end
           ) ss xvss ([], generalizable) in
-
-        if (clet_type = CLetGen) then List.iter U.unmonomorphize generalizable;
 
         Debug.print (string "Generalizable vars after signature check: "
                          ^^ print_vars generalizable);

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -298,7 +298,11 @@ let solve (rectypes : bool) (c : rawco) : unit =
             else
               begin
                 if (clet_type = CLetMono)
-                then List.iter U.monomorphize (G.unbound_tyvars s)
+                then
+                  begin
+                    List.iter U.monomorphize (G.unbound_tyvars s);
+                    List.iter U.monomorphize (G.quantifiers    s)
+                  end
                 else List.iter U.unmonomorphize generalizable;
                 s :: ss, generalizable
               end

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -269,7 +269,7 @@ let solve (rectypes : bool) (c : rawco) : unit =
                 Debug.print (nest 2
                   ((if clet_type = CLetGen
                     then string "Generalizable let-binder "
-                    else string "Let-binder ") ^^
+                    else string "Monomorphising let-binder ") ^^
                    string "with type annotation:" ^^ hardline ^^
                    string "Annotation: " ^^ print_var annotation ^^ hardline ^^
                    string "Inferred  : " ^^ print_scheme s) );
@@ -297,11 +297,25 @@ let solve (rectypes : bool) (c : rawco) : unit =
               end
             else
               begin
+                Debug.print (nest 2
+                  ((if clet_type = CLetGen
+                    then string "Generalizable let-binder "
+                    else string "Monomorphising let-binder ") ^^
+                   string "without type annotation:" ^^ hardline ^^
+                   string "Inferred type : " ^^ print_scheme s) );
                 if (clet_type = CLetMono)
                 then
                   begin
-                    List.iter U.monomorphize (G.unbound_tyvars s);
-                    List.iter U.monomorphize (G.quantifiers    s)
+                    let ftvs        = G.unbound_tyvars s in
+                    let quantifiers = G.quantifiers s in
+                    Debug.print (string "Monomorphising unbound type variables "
+                              ^^ print_vars ftvs ^^ string " of scheme "
+                              ^^ print_scheme s);
+                    List.iter U.monomorphize ftvs;
+                    Debug.print (string "Monomorphising quantifiers "
+                              ^^ print_vars quantifiers ^^ string " of scheme "
+                              ^^ print_scheme s);
+                    List.iter U.monomorphize quantifiers
                   end
                 else List.iter U.unmonomorphize generalizable;
                 s :: ss, generalizable

--- a/src/SolverLo.ml
+++ b/src/SolverLo.ml
@@ -89,10 +89,6 @@ let print_schemes vs =
    but not in the high-level interface [SolverHi]. So, it could be easily
    modified if desired. *)
 
-type clet_type =
-  | CLetMono
-  | CLetGen
-
 type rawco =
   (* Constraints *)
   | CTrue

--- a/src/SolverLo.mli
+++ b/src/SolverLo.mli
@@ -79,12 +79,6 @@ module Make
     (* JSTOLAREK: document this *)
   | CFrozen of tevar * variable
 
-    (* A trivial type scheme definition, [def x = v in C]. This binds [x] to
-       the monomorphic type scheme [v] in the constraint [C]. In other words,
-       an instantiation constraint [x w] will be satisfied by unifying [v] and
-       [w]. *)
-  | CDef of tevar * variable * rawco
-
     (* A nontrivial type scheme definition, [let [x, v, s?]* C1 in C2 [vs?]].
        In short, for each triple [x, v, s?] in the list, the term variable [x]
        is bound to the constraint abstraction [\v.C1], and the write-once
@@ -100,9 +94,6 @@ module Make
         * rawco
         * rawco
         * variable list WriteOnceRef.t
-
-  | PMono of tevar * variable
-  | PMonoInst of tevar * variable
 
   (* ---------------------------------------------------------------------- *)
 

--- a/src/SolverLo.mli
+++ b/src/SolverLo.mli
@@ -49,10 +49,6 @@ module Make
 
   type ischeme
 
-  type clet_type =
-  | CLetMono
-  | CLetGen
-
   (* The syntax of constraints is as follows. *)
   type rawco =
 

--- a/src/SolverLo.mli
+++ b/src/SolverLo.mli
@@ -89,7 +89,7 @@ module Make
        quantified in the left-hand side of the [let] construct so as to be in
        scope when [C1] is decoded. *)
   | CLet of clet_type
-        * (tevar * variable * bool * ischeme WriteOnceRef.t) list
+        * (tevar * variable * ischeme WriteOnceRef.t) list
         * variable list
         * rawco
         * rawco

--- a/src/SolverLo.mli
+++ b/src/SolverLo.mli
@@ -49,6 +49,10 @@ module Make
 
   type ischeme
 
+  type clet_type =
+  | CLetMono
+  | CLetGen
+
   (* The syntax of constraints is as follows. *)
   type rawco =
 
@@ -94,7 +98,8 @@ module Make
        [vs?] is filled with a list of type variables that must be universally
        quantified in the left-hand side of the [let] construct so as to be in
        scope when [C1] is decoded. *)
-  | CLet of (tevar * variable * bool * ischeme WriteOnceRef.t) list
+  | CLet of clet_type
+        * (tevar * variable * bool * ischeme WriteOnceRef.t) list
         * variable list
         * rawco
         * rawco

--- a/src/SolverSig.ml
+++ b/src/SolverSig.ml
@@ -13,6 +13,10 @@
 
 (* -------------------------------------------------------------------------- *)
 
+type clet_type =
+  | CLetMono
+  | CLetGen
+
 (* The type of term variables is described to the solver as follows. *)
 
 (* This signature is isomorphic to [Map.OrderedType] in OCaml's standard

--- a/src/Unifier.ml
+++ b/src/Unifier.ml
@@ -114,6 +114,9 @@ let unskolemize v =
 let is_monomorphic v =
   (TUnionFind.find v).monomorphic
 
+let set_monomorphic v b =
+  (TUnionFind.find v).monomorphic <- b
+
 let unmonomorphize v =
   (TUnionFind.find v).monomorphic <- false
 

--- a/src/Unifier.ml
+++ b/src/Unifier.ml
@@ -105,7 +105,7 @@ let is_skolem v =
 
 let skolemize v =
   let descriptor = TUnionFind.find v in
-  assert (not (descriptor.monomorphic));
+  (* assert (not (descriptor.monomorphic)); *)
   descriptor.skolem <- true
 
 let unskolemize v =

--- a/src/Unifier.ml
+++ b/src/Unifier.ml
@@ -152,6 +152,12 @@ let print (fuel : int) f v =
     else
       empty
   end ^^
+  begin
+    if ( Debug.hard && TUnionFind.is_representative v ) then
+      comma ^^ space ^^ string "repr"
+    else
+      empty
+  end ^^
   rbrace
   end
   else

--- a/src/UnifierSig.ml
+++ b/src/UnifierSig.ml
@@ -82,6 +82,7 @@ val is_skolem    : variable -> bool
 val skolemize    : variable -> unit
 val unskolemize  : variable -> unit
 val is_monomorphic  : variable -> bool
+val set_monomorphic : variable -> bool -> unit
 val monomorphize    : variable -> unit
 val unmonomorphize  : variable -> unit
 


### PR DESCRIPTION
This PR implements let_mono constraints in place of `def` and monomorphic predicates. One test is currently failing - @frank-emrich, can you take a look and tell me your thoughts? I had to comment out an assertion in `Unifier`, line 108. Apparently in some situations we are attempting to skolemize monomorphic variables. I haven't investigated yet but we need to take a look at this since it might indicate a bug. Overall constraint generation code in the client got significantly shorter, which is a huge improvement. There's no extra complexity in the solver itself, though obviously some changes were required.